### PR TITLE
Filtros Workshop

### DIFF
--- a/app/Models/Workshop.php
+++ b/app/Models/Workshop.php
@@ -64,6 +64,11 @@ class Workshop extends Model
         return $this->belongsTo(Challenge::class);
     }
 
+    public function mainTechnology()
+    {
+        return $this->belongsTo(Tag::class, "main_technology_id");
+    }
+
     function certificate()
     {
         return $this->morphOne(Certificate::class, "certifiable");

--- a/database/migrations/2024_07_18_105357_add_main_technology_id_to_workshops_table.php
+++ b/database/migrations/2024_07_18_105357_add_main_technology_id_to_workshops_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table("workshops", function (Blueprint $table) {
+            $table
+                ->foreignId("main_technology_id")
+                ->nullable()
+                ->after("status")
+                ->constrained("tags");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table("workshops", function (Blueprint $table) {
+            $table->dropForeign(["main_technology_id"]);
+            $table->dropColumn("main_technology_id");
+        });
+    }
+};

--- a/database/migrations/2024_07_18_151337_add_slug_to_tags_table.php
+++ b/database/migrations/2024_07_18_151337_add_slug_to_tags_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table("tags", function (Blueprint $table) {
+            $table
+                ->string("slug")
+                ->unique()
+                ->after("name");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table("tags", function (Blueprint $table) {
+            $table->dropColumn("slug");
+        });
+    }
+};


### PR DESCRIPTION
closes https://github.com/codante-io/roadmap/issues/432

This commit adds a new migration file to add the main_technology_id column to the workshops table and the slug column to the tags table. The main_technology_id column in the workshops table will be used to associate a main technology tag with each workshop. The slug column in the tags table will be used to store a unique identifier for each tag.

Refactor WorkshopController to include workshopQueryWithFilters method

This commit refactors the WorkshopController to include a new protected method called workshopQueryWithFilters. This method is responsible for building the query for fetching workshops with filters applied. It includes logic for filtering workshops by technology, type, and text search. The method also eager loads the tags and mainTechnology relationships for each workshop.

Update WorkshopController index method to use workshopQueryWithFilters

This commit updates the index method in the WorkshopController to use the workshopQueryWithFilters method for fetching workshops. The method now creates a query object, applies the filters using the workshopQueryWithFilters method, and returns the WorkshopCardResource collection.

Update Workshop model with mainTechnology relationship

This commit updates the Workshop model to include a mainTechnology relationship. The mainTechnology relationship is defined as a belongsTo relationship with the Tag model, using the main_technology_id foreign key.

Update WorkshopController index method to use lazy loading for relationships

This commit updates the index method in the WorkshopController to use lazy loading for the tags and mainTechnology relationships. This improves the performance of loading workshops by only loading the necessary relationships when accessed.

Refactor WorkshopController userEnteredWorkshop method

This commit refactors the userEnteredWorkshop method in the WorkshopController to include sending an email notification when a user joins a workshop for the first time. The method now sends an email to the user with a notification about their workshop enrollment.

Refactor email sender name in notification files

This commit updates the email sender name in the notification files to "Codante". This ensures that all email notifications sent from the system will display "Codante" as the sender name.

Refactor DashboardController and WorkshopController for better code organization and readability

This commit refactors the DashboardController and WorkshopController to improve code organization and readability. The changes include moving the getWorkshops method from the DashboardController to the WorkshopController for better separation of concerns, adding the WorkshopCardResource to the WorkshopController to handle the transformation of workshop data, updating the WorkshopController index method to use the cardQuery scope for fetching workshops, and removing the unused workshopUsers variable from the DashboardController.

Add getUnusedSlug endpoint to LessonController

This commit adds a new endpoint called getUnusedSlug to the LessonController. The endpoint is used to retrieve an unused slug for a lesson, ensuring that each lesson has a unique identifier.

Update WorkshopController index method to use workshopQueryWithFilters

This commit updates the index method in the WorkshopController to use the workshopQueryWithFilters method for fetching workshops. The method now creates a query object, applies the filters using the workshopQueryWithFilters method, and returns the WorkshopCardResource collection.
