### PR TITLE
feat: Add scheduled task to save avatars from GitHub

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -43,6 +43,12 @@ class Kernel extends ConsoleKernel
                 (new CompareChallengeReadmes())->checkAll();
             })
             ->weeklyOn(1, "04:30");
+
+        $schedule
+            ->call(function () {
+                (new \App\Services\SaveAvatarsFromGithub())->handle();
+            })
+            ->dailyAt("04:45");
     }
 
     /**

--- a/app/Services/SaveAvatarsFromGithub.php
+++ b/app/Services/SaveAvatarsFromGithub.php
@@ -10,19 +10,15 @@ class SaveAvatarsFromGithub
     public static function handle()
     {
         // pega todos os usuários que têm avatar
-        $users = User::whereNotNull("avatar_url")->get();
+        $users = User::where(
+            "avatar_url",
+            "like",
+            "https://avatars.githubusercontent.com%"
+        )->get();
 
         // // para cada usuário, pega o avatar do github e salva no banco
         foreach ($users as $user) {
             // a url deve começar com https://avatars.githubusercontent.com
-            if (
-                strpos(
-                    $user->avatar_url,
-                    "https://avatars.githubusercontent.com"
-                ) === false
-            ) {
-                continue;
-            }
 
             if ($user->avatar_url === null) {
                 continue;


### PR DESCRIPTION
closes https://github.com/codante-io/roadmap/issues/453

The code changes introduce a new scheduled task in the `Kernel.php` file that calls the `SaveAvatarsFromGithub` service daily at 04:45. This task retrieves all users with avatar URLs starting with "https://avatars.githubusercontent.com" and saves their avatars in the database.
