### PR TITLE
Fix Discord notification URLs for mini-project lesson comments

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,25 +34,25 @@ class Kernel extends ConsoleKernel
 
         $schedule
             ->call(function () {
-                (new \App\Services\VimeoThumbnailService())->CheckAllVideoThumbnails();
+                (new \App\Services\VimeoThumbnailService)->CheckAllVideoThumbnails();
             })
             ->dailyAt('04:00');
 
         $schedule
             ->call(function () {
-                (new CompareChallengeReadmes())->checkAll();
+                (new CompareChallengeReadmes)->checkAll();
             })
             ->weeklyOn(1, '04:30');
 
         $schedule
             ->call(function () {
-                (new \App\Services\SaveAvatarsFromGithub())->handle();
+                (new \App\Services\SaveAvatarsFromGithub)->handle();
             })
             ->dailyAt('04:45');
 
         $schedule
             ->call(function () {
-                (new \App\Services\OpenClosedChallengeLessonsRobot(new \App\Services\Discord()))->handle();
+                (new \App\Services\OpenClosedChallengeLessonsRobot(new \App\Services\Discord))->handle();
             })
             ->weeklyOn(1, '05:00');
     }

--- a/app/Events/ChallengeCompleted.php
+++ b/app/Events/ChallengeCompleted.php
@@ -18,8 +18,7 @@ class ChallengeCompleted
         public $challengeUser,
         public $challenge,
         public $user
-    ) {
-    }
+    ) {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/app/Events/ChallengeForked.php
+++ b/app/Events/ChallengeForked.php
@@ -18,8 +18,7 @@ class ChallengeForked
         public $challengeUser,
         public $challenge,
         public $user
-    ) {
-    }
+    ) {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/app/Events/ChallengeJoined.php
+++ b/app/Events/ChallengeJoined.php
@@ -18,8 +18,7 @@ class ChallengeJoined
         public $challengeUser,
         public $challenge,
         public $user
-    ) {
-    }
+    ) {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/app/Events/ReactionCreated.php
+++ b/app/Events/ReactionCreated.php
@@ -14,9 +14,7 @@ class ReactionCreated
     /**
      * Create a new event instance.
      */
-    public function __construct(public $reactionId, public $reactable)
-    {
-    }
+    public function __construct(public $reactionId, public $reactable) {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/app/Events/UserStatusUpdated.php
+++ b/app/Events/UserStatusUpdated.php
@@ -15,9 +15,7 @@ class UserStatusUpdated
     /**
      * Create a new event instance.
      */
-    public function __construct(public User $user)
-    {
-    }
+    public function __construct(public User $user) {}
 
     /**
      * Get the channels the event should broadcast on.

--- a/app/Helpers/CacheKeyBuilder.php
+++ b/app/Helpers/CacheKeyBuilder.php
@@ -7,13 +7,13 @@ class CacheKeyBuilder
     public static function buildCacheKey($key, $filters)
     {
         $filters = array_filter($filters, function ($filter) {
-            return $filter !== "" && $filter !== null;
+            return $filter !== '' && $filter !== null;
         });
 
         if (empty($filters)) {
             return $key;
         }
 
-        return $key . '-' . implode('-', $filters);
+        return $key.'-'.implode('-', $filters);
     }
 }

--- a/app/Http/Controllers/Admin/CompareReadmeController.php
+++ b/app/Http/Controllers/Admin/CompareReadmeController.php
@@ -8,11 +8,11 @@ class CompareReadmeController
 {
     public function test(string $slug)
     {
-        (new CompareChallengeReadmes())->testChallengeDescription($slug);
+        (new CompareChallengeReadmes)->testChallengeDescription($slug);
     }
 
     public function compare(string $slug)
     {
-        (new CompareChallengeReadmes())->getDiffHtml($slug);
+        (new CompareChallengeReadmes)->getDiffHtml($slug);
     }
 }

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -2,32 +2,32 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Challenge;
-use App\Models\Workshop;
-use Carbon\Carbon;
 use App\Http\Resources\Calendar\NewChallengeEventResource;
 use App\Http\Resources\Calendar\NewChallengeResolutionEventResource;
 use App\Http\Resources\Calendar\NewWorkshopEventResource;
+use App\Models\Challenge;
+use App\Models\Workshop;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+
 class CalendarController extends Controller
 {
-
     public function getEventsByDate(Request $request)
     {
-        if (!$request->input('start_date')) {
+        if (! $request->input('start_date')) {
             $startDate = Carbon::parse('2022-01-01')->toIso8601String();
         } else {
             $startDate = Carbon::parse($request->input('start_date'))->toIso8601String();
         }
 
-        if (!$request->input('end_date')) {
+        if (! $request->input('end_date')) {
             $endDate = Carbon::parse('2122-12-31')->toIso8601String();
         } else {
             $endDate = Carbon::parse($request->input('end_date'))->toIso8601String();
         }
 
-        $cacheKey = 'events_' . $startDate . '_' . $endDate;
+        $cacheKey = 'events_'.$startDate.'_'.$endDate;
 
         $events = Cache::remember($cacheKey, 3600 * 4, function () use ($request, $startDate, $endDate) {
             $challenges = Challenge::query()

--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -71,7 +71,7 @@ class CertificateController extends Controller
             throw new \Exception('Já existe um certificado.');
         }
 
-        $certificate = new Certificate();
+        $certificate = new Certificate;
         $certificate->user_id = $user->id;
         $certifiableClass = $certificate->certifiable_type = Certificate::validateCertifiable(
             $request->certifiable_type

--- a/app/Http/Controllers/LeadsController.php
+++ b/app/Http/Controllers/LeadsController.php
@@ -26,7 +26,7 @@ class LeadsController extends Controller
                 ]
             );
 
-            $emailOctopus = new EmailOctopusService();
+            $emailOctopus = new EmailOctopusService;
             $existingLead = Leads::where('email', $request->email)->first();
             $existingLeadByTag = Leads::where('email', $request->email)->where('tag', $request->tags[0])->first();
 
@@ -34,7 +34,7 @@ class LeadsController extends Controller
                 return response()->json(['error' => 'Esse e-mail já foi cadastrado anteriormente.'], 409);
             }
 
-            $lead = new Leads();
+            $lead = new Leads;
             $lead->email = $request->email;
             $lead->name = $request->name;
             $lead->phone = $request->phone;

--- a/app/Http/Controllers/PagarmeController.php
+++ b/app/Http/Controllers/PagarmeController.php
@@ -33,7 +33,7 @@ class PagarmeController extends Controller
             $planDetails->user_raised_count * 10 * 100;
 
         $couponCode = $request->coupon;
-        $coupon = (new Coupon())->getValidCoupon($couponCode, $plan_id);
+        $coupon = (new Coupon)->getValidCoupon($couponCode, $plan_id);
 
         if ($coupon) {
             $promoPrice =

--- a/app/Http/Controllers/PagarmeWebhooks.php
+++ b/app/Http/Controllers/PagarmeWebhooks.php
@@ -32,7 +32,7 @@ class PagarmeWebhooks
         if (! Str::of($eventType)->contains('order.')) {
             Discord::sendMessage('Erro, evento não trackeado', 'notificacoes-compras');
 
-            return new Response();
+            return new Response;
         }
 
         // Se não encontrarmos uma subscription com o provider_id, não vamos fazer nada.
@@ -44,7 +44,7 @@ class PagarmeWebhooks
         if (! $subscription) {
             Discord::sendMessage("Erro, não há subscription com o id {$pagarmeOrderId}", 'notificacoes-compras');
 
-            return new Response();
+            return new Response;
         }
 
         $user = User::find($subscription->user_id);
@@ -79,7 +79,7 @@ class PagarmeWebhooks
                 break;
         }
 
-        return new Response();
+        return new Response;
     }
 
     public function handlePaid(

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -9,7 +9,6 @@ use App\Models\Coupon;
 use App\Models\Plan;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 
 class SubscriptionController extends Controller
 {
@@ -60,7 +59,7 @@ class SubscriptionController extends Controller
 
         $couponInfo = null;
         if ($couponCode) {
-            $coupon = (new Coupon())->getValidCoupon($couponCode, $planId);
+            $coupon = (new Coupon)->getValidCoupon($couponCode, $planId);
 
             $couponInfo = $coupon
                 ? new CouponResource($coupon)

--- a/app/Http/Resources/Calendar/NewChallengeEventResource.php
+++ b/app/Http/Resources/Calendar/NewChallengeEventResource.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class NewChallengeEventResource extends JsonResource
 {
-
     /**
      * Transform the resource into an array.
      *
@@ -15,19 +14,18 @@ class NewChallengeEventResource extends JsonResource
      */
     public function toArray($request)
     {
-        
+
         $event = [
-            'id' => $this->id . '-' . 'challenge',
+            'id' => $this->id.'-'.'challenge',
             'title' => $this->title ?? $this->name,
             'description' => $this->short_description,
             'slug' => $this->slug,
-            'url' => '/mini-projetos/' . $this->slug,
+            'url' => '/mini-projetos/'.$this->slug,
             'type' => 'challenge',
             'datetime' => $this->weekly_featured_start_date,
             'image_url' => $this->image_url,
         ];
 
-
         return $event;
     }
-} 
+}

--- a/app/Http/Resources/Calendar/NewChallengeResolutionEventResource.php
+++ b/app/Http/Resources/Calendar/NewChallengeResolutionEventResource.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class NewChallengeResolutionEventResource extends JsonResource
 {
-
     /**
      * Transform the resource into an array.
      *
@@ -15,19 +14,18 @@ class NewChallengeResolutionEventResource extends JsonResource
      */
     public function toArray($request)
     {
-        
+
         $event = [
-            'id' => $this->id . '-' . 'challenge-resolution',
+            'id' => $this->id.'-'.'challenge-resolution',
             'title' => $this->title ?? $this->name,
             'description' => $this->short_description,
             'slug' => $this->slug,
-            'url' => '/mini-projetos/' . $this->slug,
+            'url' => '/mini-projetos/'.$this->slug,
             'type' => 'challenge-resolution',
             'datetime' => $this->solution_publish_date,
             'image_url' => $this->image_url,
         ];
 
-
         return $event;
     }
-} 
+}

--- a/app/Http/Resources/Calendar/NewWorkshopEventResource.php
+++ b/app/Http/Resources/Calendar/NewWorkshopEventResource.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class NewWorkshopEventResource extends JsonResource
 {
-
     /**
      * Transform the resource into an array.
      *
@@ -15,19 +14,18 @@ class NewWorkshopEventResource extends JsonResource
      */
     public function toArray($request)
     {
-        
+
         $event = [
-            'id' => $this->id . '-' . 'workshop',
+            'id' => $this->id.'-'.'workshop',
             'title' => $this->title ?? $this->name,
             'description' => $this->short_description,
             'slug' => $this->slug,
-            'url' => '/workshops/' . $this->slug,
+            'url' => '/workshops/'.$this->slug,
             'type' => 'workshop',
             'datetime' => $this->published_at,
             'image_url' => $this->image_url,
         ];
 
-
         return $event;
     }
-} 
+}

--- a/app/Listeners/AwardPoints.php
+++ b/app/Listeners/AwardPoints.php
@@ -14,9 +14,7 @@ class AwardPoints
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/app/Listeners/CertificateRequested.php
+++ b/app/Listeners/CertificateRequested.php
@@ -13,9 +13,7 @@ class CertificateRequested implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/app/Listeners/CommentCreated.php
+++ b/app/Listeners/CommentCreated.php
@@ -14,9 +14,7 @@ class CommentCreated implements ShouldQueue
     /**
      * Create the event listener.
      */
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     /**
      * Handle the event.

--- a/app/Listeners/EmailOctopus.php
+++ b/app/Listeners/EmailOctopus.php
@@ -24,7 +24,7 @@ class EmailOctopus
      */
     public function handle(object $event): void
     {
-        $emailOctopus = new EmailOctopusService();
+        $emailOctopus = new EmailOctopusService;
 
         if ($event instanceof ChallengeJoined) {
             $event->user->id;

--- a/app/Listeners/Registered.php
+++ b/app/Listeners/Registered.php
@@ -48,9 +48,9 @@ class Registered implements ShouldQueue
         $lead = Leads::where('email', $user->email)->first();
 
         if ($lead) {
-            (new EmailOctopusService())->updateLeadAfterSignUp($user);
+            (new EmailOctopusService)->updateLeadAfterSignUp($user);
         } else {
-            (new EmailOctopusService())->addUser($user);
+            (new EmailOctopusService)->addUser($user);
         }
     }
 }

--- a/app/Listeners/SendEventToMetaPixel.php
+++ b/app/Listeners/SendEventToMetaPixel.php
@@ -47,7 +47,7 @@ class SendEventToMetaPixel
             ->setFbp($fbp, '_fbp')
             ->setFbc($fbc, '_fbc');
         $eventId = uniqid('prefix_');
-        $customData = new CustomData();
+        $customData = new CustomData;
 
         MetaPixel::send('Lead', $eventId, $customData, $userData);
     }
@@ -62,7 +62,7 @@ class SendEventToMetaPixel
             ->setFbp($fbp, '_fbp')
             ->setFbc($fbc, '_fbc');
         $eventId = uniqid('prefix_');
-        $customData = new CustomData();
+        $customData = new CustomData;
 
         MetaPixel::send(
             'CompleteRegistration',
@@ -82,12 +82,12 @@ class SendEventToMetaPixel
             ->setFbp($fbp, '_fbp')
             ->setFbc($fbc, '_fbc');
 
-        $content = (new Content())
+        $content = (new Content)
             ->setProductId($event->subscription->id)
             ->setItemPrice($event->subscription->price_paid_in_cents / 100)
             ->setQuantity(1);
 
-        $customData = (new CustomData())
+        $customData = (new CustomData)
             ->setContents([$content])
             ->setCurrency('brl')
             ->setValue($event->subscription->price_paid_in_cents / 100);

--- a/app/Listeners/UserStatusUpdated.php
+++ b/app/Listeners/UserStatusUpdated.php
@@ -28,6 +28,6 @@ class UserStatusUpdated implements ShouldQueue
 
     private function updateUserInEmailList($user): void
     {
-        (new \App\Services\Mail\EmailOctopusService())->updateUser($user);
+        (new \App\Services\Mail\EmailOctopusService)->updateUser($user);
     }
 }

--- a/app/Mail/PaymentConfirmed.php
+++ b/app/Mail/PaymentConfirmed.php
@@ -17,8 +17,7 @@ class PaymentConfirmed extends Mailable
     public function __construct(
         public User $user,
         public Subscription $subscription
-    ) {
-    }
+    ) {}
 
     public function envelope(): Envelope
     {

--- a/app/Mail/PaymentRefunded.php
+++ b/app/Mail/PaymentRefunded.php
@@ -17,8 +17,7 @@ class PaymentRefunded extends Mailable
     public function __construct(
         public User $user,
         public Subscription $subscription
-    ) {
-    }
+    ) {}
 
     public function envelope(): Envelope
     {

--- a/app/Mail/PaymentRefused.php
+++ b/app/Mail/PaymentRefused.php
@@ -17,8 +17,7 @@ class PaymentRefused extends Mailable
     public function __construct(
         public User $user,
         public Subscription $subscription
-    ) {
-    }
+    ) {}
 
     public function envelope(): Envelope
     {

--- a/app/Mail/SubscriptionCanceled.php
+++ b/app/Mail/SubscriptionCanceled.php
@@ -20,8 +20,7 @@ class SubscriptionCanceled extends Mailable
     public function __construct(
         public User $user,
         public Subscription $subscription
-    ) {
-    }
+    ) {}
 
     /**
      * Get the message envelope.

--- a/app/Mail/UserJoinedChallenge.php
+++ b/app/Mail/UserJoinedChallenge.php
@@ -20,8 +20,7 @@ class UserJoinedChallenge extends Mailable
     public function __construct(
         public User $user,
         public Challenge $challenge
-    ) {
-    }
+    ) {}
 
     /**
      * Get the message envelope.

--- a/app/Mail/UserRegistered.php
+++ b/app/Mail/UserRegistered.php
@@ -17,9 +17,7 @@ class UserRegistered extends Mailable
     /**
      * Create a new message instance.
      */
-    public function __construct(public User $user)
-    {
-    }
+    public function __construct(public User $user) {}
 
     /**
      * Get the message envelope.

--- a/app/Mail/UserSubscribedToPlan.php
+++ b/app/Mail/UserSubscribedToPlan.php
@@ -17,8 +17,7 @@ class UserSubscribedToPlan extends Mailable
     public function __construct(
         public User $user,
         public Subscription $subscription
-    ) {
-    }
+    ) {}
 
     public function envelope(): Envelope
     {

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -325,7 +325,8 @@ class Challenge extends Model
         }
     }
 
-    public function scopeOrderByCustom($query, $orderBy) {
+    public function scopeOrderByCustom($query, $orderBy)
+    {
         switch ($orderBy) {
             case 'facil':
                 $query->orderBy('difficulty', 'asc');
@@ -353,21 +354,23 @@ class Challenge extends Model
         return $query;
     }
 
-    private function hideDescription($description) {
+    private function hideDescription($description)
+    {
         $description = substr($description, 0, 400);
         $description = substr($description, 0, strrpos($description, "\n") + 1);
+
         return $description;
     }
 
-    public function getDescription() {
+    public function getDescription()
+    {
         $isPro = auth()->check() && auth()->user()->is_pro;
         $isPremiumChallenge = $this->is_premium;
 
-        if ($isPro || !$isPremiumChallenge || $this->isWeeklyFeatured()) {
+        if ($isPro || ! $isPremiumChallenge || $this->isWeeklyFeatured()) {
             return $this->description;
         }
 
         return $this->hideDescription($this->description);
     }
 }
-

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -98,10 +98,18 @@ class Comment extends Model
 
         if ($this->commentable_type == "App\Models\Lesson") {
             $lesson = $this->commentable;
-            $workshop = $lesson->lessonable;
+            $lessonable = $lesson->lessonable;
             $lessonSlug = $lesson->slug;
 
-            return '/workshops/'.$workshop->slug.'/'.$lessonSlug;
+            // Check if the lesson belongs to a Challenge (mini-projeto)
+            if ($lessonable instanceof \App\Models\Challenge) {
+                return '/mini-projetos/'.$lessonable->slug.'/resolucao/'.$lessonSlug;
+            }
+
+            // Check if the lesson belongs to a Workshop
+            if ($lessonable instanceof \App\Models\Workshop) {
+                return '/workshops/'.$lessonable->slug.'/'.$lessonSlug;
+            }
         }
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -132,7 +132,7 @@ class User extends Authenticatable
     ): Subscription {
         $plan = Plan::findOrFail($planId);
 
-        $subscription = new Subscription();
+        $subscription = new Subscription;
         $subscription->user_id = $this->id;
         $subscription->plan_id = $planId;
         $subscription->provider_id = $providerId;
@@ -189,7 +189,7 @@ class User extends Authenticatable
 
     public function removeFromEmailLists()
     {
-        $emailOctopus = new EmailOctopusService();
+        $emailOctopus = new EmailOctopusService;
         $emailOctopus->deleteUser($this);
     }
 
@@ -200,7 +200,7 @@ class User extends Authenticatable
 
     public function changeAvatar(UploadedFile $avatar)
     {
-        $base62 = new Base62();
+        $base62 = new Base62;
         $encodedEmail = $base62->encode($this->email);
 
         // reduce image size

--- a/app/Notifications/CertificatePublishedNotification.php
+++ b/app/Notifications/CertificatePublishedNotification.php
@@ -58,7 +58,7 @@ class CertificatePublishedNotification extends Notification implements ShouldQue
             $message = "Seu certificado com ID {$this->certificate->id} foi publicado!";
         }
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->from('contato@codante.io', 'Codante')
             ->subject('[Codante] Seu certificado foi publicado!')
             ->greeting("Olá $firstName")

--- a/app/Notifications/CertificateRequestedNotification.php
+++ b/app/Notifications/CertificateRequestedNotification.php
@@ -43,7 +43,7 @@ class CertificateRequestedNotification extends Notification
                 ? "Recebemos a sua solicitação de certificado para o Mini Projeto {$this->certificate->certifiable->challenge->name}!"
                 : "Seu certificado com ID {$this->certificate->id} foi solicitado e em breve estará disponível!";
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->from('contato@codante.io', 'Codante')
             ->subject('[Codante] Recebemos sua solicitação de certificado!')
             ->greeting("Olá $firstName")

--- a/app/Notifications/ChallengeUserCommentNotification.php
+++ b/app/Notifications/ChallengeUserCommentNotification.php
@@ -46,7 +46,7 @@ class ChallengeUserCommentNotification extends Notification
         $firstName = Str::title(explode(' ', $notifiable->name)[0]);
         $frontUrl = config('app.frontend_url');
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->from('contato@codante.io', 'Codante')
             ->subject('[Codante] Alguém comentou na sua submissão!')
             ->greeting("Olá $firstName")

--- a/app/Notifications/ChallengeUserReplyCommentNotification.php
+++ b/app/Notifications/ChallengeUserReplyCommentNotification.php
@@ -46,7 +46,7 @@ class ChallengeUserReplyCommentNotification extends Notification
         $firstName = Str::title(explode(' ', $notifiable->name)[0]);
         $frontUrl = config('app.frontend_url');
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->from('contato@codante.io', 'Codante')
             ->subject('[Codante] Uma pessoa respondeu seu comentário!')
             ->greeting("Olá $firstName")

--- a/app/Notifications/UnlistedChallengeUserNotification.php
+++ b/app/Notifications/UnlistedChallengeUserNotification.php
@@ -49,7 +49,7 @@ class UnlistedChallengeUserNotification extends Notification
 
         $frontUrl = config('app.frontend_url');
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->from('contato@codante.io', 'Codante')
             ->subject('[Codante] Encontramos um problema na sua submissão!')
             ->greeting("Olá $firstName")

--- a/app/Notifications/UserJoinedWorkshop.php
+++ b/app/Notifications/UserJoinedWorkshop.php
@@ -39,7 +39,7 @@ class UserJoinedWorkshop extends Notification implements ShouldQueue
     {
         $type = $this->workshop->is_standalone ? 'workshop' : 'tutorial';
 
-        return (new MailMessage())
+        return (new MailMessage)
             ->subject('Você se inscreveu em um novo '.$type.'!')
             ->markdown('emails.user-joined-workshop', [
                 'workshop' => $this->workshop,

--- a/app/Services/ChallengeRepository.php
+++ b/app/Services/ChallengeRepository.php
@@ -55,6 +55,7 @@ class ChallengeRepository
     {
         $query = Challenge::query();
         $query = $this->challengeCardsBaseQuery($query, $currentUser);
+
         return $query;
     }
 

--- a/app/Services/OpenClosedChallengeLessonsRobot.php
+++ b/app/Services/OpenClosedChallengeLessonsRobot.php
@@ -12,9 +12,7 @@ class OpenClosedChallengeLessonsRobot
 
     private static $mainTechnologyHackatonId = 225;
 
-    public function __construct(protected Discord $discord)
-    {
-    }
+    public function __construct(protected Discord $discord) {}
 
     public function handle()
     {

--- a/database/seeders/SaveAvatarsFromGithub.php
+++ b/database/seeders/SaveAvatarsFromGithub.php
@@ -12,7 +12,7 @@ class SaveAvatarsFromGithub extends Seeder
      */
     public function run(): void
     {
-        $service = new SaveAvatarsFromGithubService();
+        $service = new SaveAvatarsFromGithubService;
         $service->handle();
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Services\OpenClosedChallengeLessonsRobot;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -21,4 +20,3 @@ Route::get('/', function () {
 Route::fallback(function () {
     return response()->json(['message' => 'Not Found'], 404);
 });
-

--- a/tests/Feature/CommentsTest.php
+++ b/tests/Feature/CommentsTest.php
@@ -15,7 +15,7 @@ class CommentsTest extends TestCase
     use RefreshDatabase;
 
     //setup
-    public function setUp(): void
+    protected function setUp(): void
     {
         // mock Discord
         parent::setUp();
@@ -23,7 +23,7 @@ class CommentsTest extends TestCase
     }
 
     //teardown
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         \Mockery::close();
         parent::tearDown();

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -14,7 +14,7 @@ class HomeTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
## Summary
• Fixed incorrect Discord notification URLs for comments on mini-project lessons
• Previously all lesson comments generated workshop URLs (`/workshops/{slug}/{lesson}`)  
• Now properly differentiates between workshop and mini-project lessons
• Mini-project lessons generate correct URLs (`/mini-projetos/{slug}/resolucao/{lesson}`)

## Root Cause
The `Comment::getCommentableUrl()` method in `app/Models/Comment.php` assumed all lessons belonged to workshops, but lessons can be polymorphically related to either workshops or challenges (mini-projects).

## Technical Changes
**File: `app/Models/Comment.php`**
- Updated `getCommentableUrl()` method to check `lessonable` type using `instanceof`
- Added logic for `Challenge` instances → generates `/mini-projetos/{slug}/resolucao/{lesson}` URLs
- Maintained existing logic for `Workshop` instances → generates `/workshops/{slug}/{lesson}` URLs

## Test Plan
- [x] All existing PHPUnit tests pass
- [x] Laravel Pint code formatting applied
- [x] No breaking changes to existing functionality  
- [ ] Manual testing: Create comment on mini-project lesson, verify Discord notification has correct URL
- [ ] Manual testing: Create comment on workshop lesson, verify Discord notification still works

## Before/After Example
**Before (incorrect):**
```
💬 Um novo comentário foi feito por Neto Mendes em App\Models\Lesson 474: Muito bom, aprendi muito \!\!\!
🔗https://codante.io/workshops/calculadora-de-imc-com-react/finalizacao-01
```

**After (correct):**
```  
💬 Um novo comentário foi feito por Neto Mendes em App\Models\Lesson 474: Muito bom, aprendi muito \!\!\!
🔗https://codante.io/mini-projetos/calculadora-de-imc-com-react/resolucao/finalizacao-01
```

🤖 Generated with [Claude Code](https://claude.ai/code)