### PR TITLE
Fix Discord notification URLs for mini-project lesson comments

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -98,10 +98,18 @@ class Comment extends Model
 
         if ($this->commentable_type == "App\Models\Lesson") {
             $lesson = $this->commentable;
-            $workshop = $lesson->lessonable;
+            $lessonable = $lesson->lessonable;
             $lessonSlug = $lesson->slug;
 
-            return '/workshops/'.$workshop->slug.'/'.$lessonSlug;
+            // Check if the lesson belongs to a Challenge (mini-projeto)
+            if ($lessonable instanceof \App\Models\Challenge) {
+                return '/mini-projetos/'.$lessonable->slug.'/resolucao/'.$lessonSlug;
+            }
+
+            // Check if the lesson belongs to a Workshop
+            if ($lessonable instanceof \App\Models\Workshop) {
+                return '/workshops/'.$lessonable->slug.'/'.$lessonSlug;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
• Fixed incorrect Discord notification URLs for comments on mini-project lessons
• Previously all lesson comments generated workshop URLs (`/workshops/{slug}/{lesson}`)  
• Now properly differentiates between workshop and mini-project lessons
• Mini-project lessons generate correct URLs (`/mini-projetos/{slug}/resolucao/{lesson}`)

## Root Cause
The `Comment::getCommentableUrl()` method in `app/Models/Comment.php` assumed all lessons belonged to workshops, but lessons can be polymorphically related to either workshops or challenges (mini-projects).

## Technical Changes
**File: `app/Models/Comment.php` (only file changed)**
- Updated `getCommentableUrl()` method to check `lessonable` type using `instanceof`
- Added logic for `Challenge` instances → generates `/mini-projetos/{slug}/resolucao/{lesson}` URLs
- Maintained existing logic for `Workshop` instances → generates `/workshops/{slug}/{lesson}` URLs

## Test Plan
- [x] All existing PHPUnit tests pass
- [x] No breaking changes to existing functionality  
- [ ] Manual testing: Create comment on mini-project lesson, verify Discord notification has correct URL
- [ ] Manual testing: Create comment on workshop lesson, verify Discord notification still works

## Before/After Example
**Before (incorrect):**
```
💬 Um novo comentário foi feito por Neto Mendes em App\Models\Lesson 474: Muito bom, aprendi muito \!\!\!
🔗https://codante.io/workshops/calculadora-de-imc-com-react/finalizacao-01
```

**After (correct):**
```  
💬 Um novo comentário foi feito por Neto Mendes em App\Models\Lesson 474: Muito bom, aprendi muito \!\!\!
🔗https://codante.io/mini-projetos/calculadora-de-imc-com-react/resolucao/finalizacao-01
```

🤖 Generated with [Claude Code](https://claude.ai/code)